### PR TITLE
Handle Gemfile not being in project root

### DIFF
--- a/src/frameworkProcess.ts
+++ b/src/frameworkProcess.ts
@@ -102,12 +102,10 @@ export class FrameworkProcess implements vscode.Disposable {
         if (data.startsWith('Fast Debugger') && onDebugStarted) {
           log.info('Notifying debug session that test process is ready to debug');
           onDebugStarted()
+        } else if (this.testRunStarted) {
+          log.warn('%s', data);
         } else {
-	        if (this.testRunStarted) {
-            log.warn('%s', data);
-          } else {
-            this.preTestErrorLines.push(data)
-          }
+          this.preTestErrorLines.push(data)
         }
       })
 
@@ -148,6 +146,8 @@ export class FrameworkProcess implements vscode.Disposable {
     let log = this.log.getChildLogger({label: 'onDataReceived'})
 
     let getTest = (testId: string): vscode.TestItem => {
+      // TODO: Pass dirs between workspace folder and gemfile folder to normaliseTestId
+      //if (this.spawnArgs.cwd != this.
       testId = this.testManager.normaliseTestId(testId)
       return this.testManager.getOrCreateTestItem(testId)
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,13 +92,20 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(profiles.debugProfile);
     context.subscriptions.push(factory);
 
+    controller.refreshHandler = async cancellationToken => {
+      controller.items.replace([])
+      factory.getLoader().dispose()
+      await factory.getLoader().discoverAllFilesInWorkspace();
+      await factory.getLoader().enqueueItemsForLoading(undefined, cancellationToken)
+    }
+
     controller.resolveHandler = async test => {
       log.debug('resolveHandler called', test)
       if (!test) {
         await factory.getLoader().discoverAllFilesInWorkspace();
       } else if (test.canResolveChildren && test.id.endsWith(".rb")) {
         // Only load files - folders are handled by FileWatchers, and contexts will be loaded when their file is loaded/modified
-        await factory.getLoader().loadTestItem(test);
+        await factory.getLoader().enqueueItemsForLoading(test);
       }
     };
 

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -223,7 +223,7 @@ export class TestRunner implements vscode.Disposable {
    */
   private async runTestFramework (testCommand: { command: string, args: string[] }, testRun: vscode.TestRun, profile?: vscode.TestRunProfile): Promise<void> {
     const spawnArgs: childProcess.SpawnOptions = {
-      cwd: this.workspace?.uri.fsPath,
+      cwd: await this.manager.config.findParentGemfileForTests(this.log, testCommand.args) || this.workspace?.uri.fsPath,
       shell: true,
       env: this.manager.config.getProcessEnv()
     };

--- a/src/testSuiteManager.ts
+++ b/src/testSuiteManager.ts
@@ -72,6 +72,7 @@ export class TestSuiteManager {
     if (testId.startsWith(`.${path.sep}`)) {
       testId = testId.substring(2)
     }
+    log.debug('Relative', { id: testId, testDir: this.config.getRelativeTestDirectory()})
     if (testId.startsWith(this.config.getRelativeTestDirectory())) {
       testId = testId.replace(this.config.getRelativeTestDirectory(), '')
     }

--- a/test/suite/minitest/minitest.test.ts
+++ b/test/suite/minitest/minitest.test.ts
@@ -149,7 +149,7 @@ suite('Extension Test for Minitest', function() {
       )
 
       // Resolve a file (e.g. by clicking on it in the test explorer)
-      await testLoader.loadTestItem(absTestItem)
+      await testLoader.enqueueItemsForLoading(absTestItem)
 
       // Tests in that file have now been added to suite
       testItemCollectionMatches(testController.items,

--- a/test/suite/rspec/rspec.test.ts
+++ b/test/suite/rspec/rspec.test.ts
@@ -169,7 +169,7 @@ suite('Extension Test for RSpec', function() {
       )
 
       // Resolve a file (e.g. by clicking on it in the test explorer)
-      await testLoader.loadTestItem(absSpecItem)
+      await testLoader.enqueueItemsForLoading(absSpecItem)
 
       // Tests in that file have now been added to suite
       testItemCollectionMatches(testController.items,


### PR DESCRIPTION
Finds the appropriate Gemfile for the test being run if possible and sets the test runner process' working directory to that Gemfile's dir

Fixes: #5 